### PR TITLE
Fix note color save bug

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -69,7 +69,14 @@ export default function Home() {
 
   const changeNoteColor = (id: number, color: string) => {
     setNotes(notes.map(note =>
-      note.id === id ? { ...note, color } : note
+      note.id === id
+        ? {
+            ...note,
+            color,
+            isEdited: true,
+            lastSaved: new Date().toLocaleTimeString(),
+          }
+        : note
     ));
   };
 


### PR DESCRIPTION
## Summary
- persist edited notes when only color changes

## Testing
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_688cb56a17d48332bbca984dbbdeee1e